### PR TITLE
[STAT-001] 습관별 월간 달성률 구현

### DIFF
--- a/app/(app)/stats.tsx
+++ b/app/(app)/stats.tsx
@@ -1,12 +1,99 @@
-import React from 'react';
-import { Text, View } from 'react-native';
+import { ChevronLeft, ChevronRight } from 'lucide-react-native';
+import React, { useState } from 'react';
+import { ActivityIndicator, FlatList, Pressable, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useMonthlyStats } from '../../src/hooks/useMonthlyStats';
+import type { HabitAchievement } from '../../src/hooks/useMonthlyStats';
+
+function AchievementBar({ rate }: { rate: number }) {
+  const color = rate >= 80 ? '#4F7942' : rate >= 50 ? '#F59E0B' : '#EF4444';
+  return (
+    <View className="mt-2 h-2 bg-gray-100 rounded-full overflow-hidden">
+      <View
+        className="h-full rounded-full"
+        style={{ width: `${rate}%`, backgroundColor: color }}
+      />
+    </View>
+  );
+}
+
+function AchievementItem({ item }: { item: HabitAchievement }) {
+  const { habit, targetCount, completedCount, rate } = item;
+  return (
+    <View className="bg-white rounded-2xl px-4 py-4 mb-2">
+      <View className="flex-row items-center justify-between">
+        <Text className="text-base font-medium text-text-primary flex-1 mr-3" numberOfLines={1}>
+          {habit.name}
+        </Text>
+        <Text className="text-base font-bold" style={{ color: rate >= 80 ? '#4F7942' : rate >= 50 ? '#F59E0B' : '#EF4444' }}>
+          {rate}%
+        </Text>
+      </View>
+      <AchievementBar rate={rate} />
+      <Text className="text-xs text-text-secondary mt-1.5">
+        {completedCount} / {targetCount}일 완료
+      </Text>
+    </View>
+  );
+}
 
 export default function StatsScreen() {
+  const today = new Date();
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth() + 1);
+
+  const { achievements, isLoading } = useMonthlyStats(year, month);
+
+  const goPrev = () => {
+    if (month === 1) { setYear(y => y - 1); setMonth(12); }
+    else setMonth(m => m - 1);
+  };
+
+  const goNext = () => {
+    const isCurrentMonth = year === today.getFullYear() && month === today.getMonth() + 1;
+    if (isCurrentMonth) return;
+    if (month === 12) { setYear(y => y + 1); setMonth(1); }
+    else setMonth(m => m + 1);
+  };
+
+  const isCurrentMonth = year === today.getFullYear() && month === today.getMonth() + 1;
+
   return (
-    <SafeAreaView className="flex-1 bg-background items-center justify-center">
-      <Text className="text-4xl mb-3">📊</Text>
-      <Text className="text-text-secondary">월간 통계는 곧 추가될 예정이에요!</Text>
+    <SafeAreaView className="flex-1 bg-background">
+      {/* 헤더 */}
+      <View className="px-5 pt-4 pb-2">
+        <Text className="text-xl font-bold text-text-primary">월간 통계</Text>
+      </View>
+
+      {/* 월 선택 */}
+      <View className="flex-row items-center justify-center gap-6 py-3">
+        <Pressable onPress={goPrev} className="p-2">
+          <ChevronLeft size={22} color="#4F7942" />
+        </Pressable>
+        <Text className="text-lg font-semibold text-text-primary w-24 text-center">
+          {year}.{String(month).padStart(2, '0')}
+        </Text>
+        <Pressable onPress={goNext} className="p-2" disabled={isCurrentMonth}>
+          <ChevronRight size={22} color={isCurrentMonth ? '#D1D5DB' : '#4F7942'} />
+        </Pressable>
+      </View>
+
+      {/* 목록 */}
+      {isLoading ? (
+        <ActivityIndicator className="mt-10" color="#4F7942" />
+      ) : achievements.length === 0 ? (
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-4xl mb-3">🌰</Text>
+          <Text className="text-text-secondary">이 달에 등록된 습관이 없어요.</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={achievements}
+          keyExtractor={(item) => item.habit.id}
+          contentContainerClassName="px-5 pb-6"
+          renderItem={({ item }) => <AchievementItem item={item} />}
+        />
+      )}
     </SafeAreaView>
   );
 }

--- a/src/hooks/useHabitLogs.ts
+++ b/src/hooks/useHabitLogs.ts
@@ -1,8 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchLogsByDate } from '../api/habitLogs';
-import { IS_MOCK, MOCK_LOGS } from '../lib/mockData';
+import { fetchLogsByDate, fetchLogsByMonth } from '../api/habitLogs';
+import { IS_MOCK, MOCK_LOGS, MOCK_MONTH_LOGS } from '../lib/mockData';
 
 export const logsByDateKey = (date: string) => ['habit_logs', date] as const;
+export const logsByMonthKey = (start: string, end: string) => ['habit_logs_month', start, end] as const;
 
 export function useHabitLogs(date: string) {
   return useQuery({
@@ -11,5 +12,15 @@ export function useHabitLogs(date: string) {
       ? () => Promise.resolve(MOCK_LOGS.filter((l) => l.date === date))
       : () => fetchLogsByDate(date),
     staleTime: 1000 * 60,
+  });
+}
+
+export function useHabitLogsByMonth(start: string, end: string) {
+  return useQuery({
+    queryKey: logsByMonthKey(start, end),
+    queryFn: IS_MOCK
+      ? () => Promise.resolve(MOCK_MONTH_LOGS.filter((l) => l.date >= start && l.date <= end))
+      : () => fetchLogsByMonth(start, end),
+    staleTime: 1000 * 60 * 5,
   });
 }

--- a/src/hooks/useMonthlyStats.ts
+++ b/src/hooks/useMonthlyStats.ts
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+import { useHabitLogsByMonth } from './useHabitLogs';
+import { useHabits } from './useHabits';
+import type { Habit, HabitLog } from '../types/habit';
+import { getMonthRange } from '../lib/dateUtils';
+
+export interface HabitAchievement {
+  habit: Habit;
+  targetCount: number;  // 해당 월에 해야 할 일수
+  completedCount: number; // 실제 완료한 일수
+  rate: number;         // 달성률 (0~100)
+}
+
+function getDatesInMonth(year: number, month: number): Date[] {
+  const dates: Date[] = [];
+  const lastDay = new Date(year, month, 0).getDate();
+  const today = new Date();
+  const isCurrentMonth = today.getFullYear() === year && today.getMonth() + 1 === month;
+  const maxDay = isCurrentMonth ? today.getDate() : lastDay;
+
+  for (let day = 1; day <= maxDay; day++) {
+    dates.push(new Date(year, month - 1, day));
+  }
+  return dates;
+}
+
+function calcAchievements(
+  habits: Habit[],
+  logs: HabitLog[],
+  year: number,
+  month: number,
+): HabitAchievement[] {
+  const dates = getDatesInMonth(year, month);
+
+  return habits.map((habit) => {
+    const targetDates = dates.filter((d) => habit.target_days.includes(d.getDay()));
+    const targetCount = targetDates.length;
+
+    const completedCount = logs.filter(
+      (l) => l.habit_id === habit.id && l.completed
+    ).length;
+
+    const rate = targetCount === 0 ? 0 : Math.round((completedCount / targetCount) * 100);
+
+    return { habit, targetCount, completedCount, rate };
+  });
+}
+
+export function useMonthlyStats(year: number, month: number) {
+  const { start, end } = getMonthRange(year, month);
+  const { data: habits = [], isLoading: habitsLoading } = useHabits();
+  const { data: logs = [], isLoading: logsLoading } = useHabitLogsByMonth(start, end);
+
+  const achievements = useMemo(
+    () => calcAchievements(habits, logs, year, month),
+    [habits, logs, year, month],
+  );
+
+  return {
+    achievements,
+    isLoading: habitsLoading || logsLoading,
+  };
+}

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -7,14 +7,51 @@ export const MOCK_HABITS: Habit[] = [
   { id: '4', user_id: 'mock', name: '명상 10분', target_days: [1, 2, 3, 4, 5], created_at: '' },
 ];
 
+function getTodayStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function getDateStr(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+// 이번 달 mock 로그 생성 (오늘까지)
+function generateMockMonthLogs(): HabitLog[] {
+  const logs: HabitLog[] = [];
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth();
+  let logId = 100;
+
+  for (let day = 1; day <= today.getDate(); day++) {
+    const date = new Date(year, month, day);
+    const weekday = date.getDay();
+    const dateStr = getDateStr(date);
+
+    for (const habit of MOCK_HABITS) {
+      if (!habit.target_days.includes(weekday)) continue;
+      // 습관별로 다른 달성률 시뮬레이션
+      const rand = ((habit.id.charCodeAt(0) * day * 7) % 100);
+      const thresholds: Record<string, number> = { '1': 80, '2': 50, '3': 90, '4': 60 };
+      const completed = rand < (thresholds[habit.id] ?? 70);
+      logs.push({
+        id: `mock-${logId++}`,
+        habit_id: habit.id,
+        user_id: 'mock',
+        date: dateStr,
+        completed,
+      });
+    }
+  }
+  return logs;
+}
+
 export const MOCK_LOGS: HabitLog[] = [
   { id: 'l1', habit_id: '1', user_id: 'mock', date: getTodayStr(), completed: true },
   { id: 'l2', habit_id: '3', user_id: 'mock', date: getTodayStr(), completed: true },
 ];
 
-function getTodayStr(): string {
-  const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-}
+export const MOCK_MONTH_LOGS: HabitLog[] = generateMockMonthLogs();
 
 export const IS_MOCK = process.env.EXPO_PUBLIC_USE_MOCK === 'true';


### PR DESCRIPTION
## Summary
- `useMonthlyStats` 훅으로 습관별 달성률 계산 (`완료일 / 해야 할 일수 × 100`)
- `useHabitLogsByMonth` 훅 추가로 월별 로그 일괄 조회
- 통계 화면에 달성률 바 + 월 선택 네비게이션 UI 구현
- mock 모드에서 테스트할 수 있도록 월간 로그 시뮬레이션 데이터 추가

## Test plan
- [ ] mock 모드에서 통계 탭 진입 시 습관 목록과 달성률이 표시되는지 확인
- [ ] 달성률 바 색상: 80% 이상 초록, 50~79% 노랑, 50% 미만 빨강
- [ ] 완료일 / 목표일수 텍스트 정확히 표시되는지 확인
- [ ] 이전 달 버튼으로 과거 월 조회 가능한지 확인
- [ ] 현재 달일 때 다음 달 버튼 비활성화 확인

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)